### PR TITLE
Fixed issue #13

### DIFF
--- a/src/TestStack.Seleno.Tests/Configuration/AppConfiguratorTests.cs
+++ b/src/TestStack.Seleno.Tests/Configuration/AppConfiguratorTests.cs
@@ -1,18 +1,37 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using TestStack.Seleno.Configuration;
+using TestStack.Seleno.Configuration.Contracts;
+using TestStack.Seleno.Tests.Specify;
+using TestStack.Seleno.Tests.TestInfrastructure;
 
 namespace TestStack.Seleno.Tests.Configuration
 {
-    [TestFixture]
-    public class AppConfiguratorTests
+    public abstract class WithAppConfigurator : SpecificationFor<AppConfigurator>
     {
-        [Test]
-        public void should_be_able_to_create_IisExpressWebServer()
+        protected ISelenoApplication Host;
+
+        public override void InitialiseSystemUnderTest()
         {
-            var configurator = new AppConfigurator();
-            var app = configurator.CreateApplication();
-            app.Should().NotBeNull();
+            SUT = TestObjectFactory.TestableAppConfigurator();
+        }
+    }
+
+    public class when_creating_default_Application_with_no_overrides : WithAppConfigurator
+    {
+        public when_creating_default_Application_with_no_overrides()
+        {
+            Host = SUT.CreateApplication();
+        }
+
+        public void Then_it_should_create_the_application()
+        {
+            Host.Should().NotBeNull();
+        }
+
+        public void AndThen_it_should_be_a_SelenoApplication()
+        {
+            Host.Should().BeOfType<SelenoApplication>();
         }
     }
 }

--- a/src/TestStack.Seleno.Tests/TestInfrastructure/TestObjectFactory.cs
+++ b/src/TestStack.Seleno.Tests/TestInfrastructure/TestObjectFactory.cs
@@ -1,0 +1,27 @@
+﻿using TestStack.Seleno.Configuration;
+using TestStack.Seleno.Configuration.Contracts;
+using TestStack.Seleno.Configuration.Screenshots;
+using TestStack.Seleno.Configuration.WebServers;
+using TestStack.Seleno.Infrastructure.Logging.Loggers;
+
+using NSubstitute;
+using OpenQA.Selenium;
+
+namespace TestStack.Seleno.Tests.TestInfrastructure
+{
+    public static class TestObjectFactory
+    {
+        public static AppConfigurator TestableAppConfigurator()
+        {
+            var webApplication = new WebApplication(Substitute.For<IProjectLocation>(), 45123);
+            var configurator = new AppConfigurator()
+                .ProjectToTest(webApplication)
+                .WithWebServer(Substitute.For<IWebServer>())
+                .WithWebDriver(() => Substitute.For<IWebDriver>())
+                .UsingCamera(new NullCamera())
+                .UsingLogger(new NullLogFactory());
+
+            return configurator;
+        }
+    }
+}

--- a/src/TestStack.Seleno.Tests/TestStack.Seleno.Tests.csproj
+++ b/src/TestStack.Seleno.Tests/TestStack.Seleno.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Specify\SpecificationFor.cs" />
     <Compile Include="Specify\SpecifySpecs.cs" />
     <Compile Include="Specify\SpecStoryMetaDataScanner.cs" />
+    <Compile Include="TestInfrastructure\TestObjectFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/TestStack.Seleno/Configuration/AppConfigurator.cs
+++ b/src/TestStack.Seleno/Configuration/AppConfigurator.cs
@@ -12,17 +12,17 @@ namespace TestStack.Seleno.Configuration
 {
     public class AppConfigurator : IAppConfigurator
     {
-        private WebApplication _webApplication;
-        private IWebServer _webServer;
-        private ICamera _camera = new NullCamera();
-        private Func<IWebDriver> _webDriver = BrowserFactory.FireFox;
-        private ILogFactory _logFactory = new ConsoleLogFactory();
+        protected WebApplication _webApplication;
+        protected IWebServer _webServer;
+        protected ICamera _camera = new NullCamera();
+        protected Func<IWebDriver> _webDriver = BrowserFactory.FireFox;
+        protected ILogFactory _logFactory = new ConsoleLogFactory();
 
         public ISelenoApplication CreateApplication()
         {
             _logFactory
                 .GetLogger(GetType())
-                .InfoFormat("Seleno v{0}, .NET Framework v{1}", 
+                .InfoFormat("Seleno v{0}, .NET Framework v{1}",
                     typeof(SelenoApplicationRunner).Assembly.GetName().Version, Environment.Version);
 
             var container = BuildContainer();
@@ -40,29 +40,34 @@ namespace TestStack.Seleno.Configuration
             return container;
         }
 
-        public void ProjectToTest(WebApplication webApplication)
+        public AppConfigurator ProjectToTest(WebApplication webApplication)
         {
             _webApplication = webApplication;
+            return this;
         }
 
-        public void WithWebServer(IWebServer webServer)
+        public AppConfigurator WithWebServer(IWebServer webServer)
         {
             _webServer = webServer;
-        } 
+            return this;
+        }
 
-        public void WithWebDriver(Func<IWebDriver> webDriver)
+        public AppConfigurator WithWebDriver(Func<IWebDriver> webDriver)
         {
             _webDriver = webDriver;
+            return this;
         }
 
-        public void UsingCamera(ICamera camera)
+        public AppConfigurator UsingCamera(ICamera camera)
         {
             _camera = camera;
+            return this;
         }
 
-        public void UsingLogger(ILogFactory logFactory)
+        public AppConfigurator UsingLogger(ILogFactory logFactory)
         {
             _logFactory = logFactory;
+            return this;
         }
     }
 }

--- a/src/TestStack.Seleno/Configuration/Contracts/IAppConfigurator.cs
+++ b/src/TestStack.Seleno/Configuration/Contracts/IAppConfigurator.cs
@@ -7,10 +7,10 @@ namespace TestStack.Seleno.Configuration.Contracts
 {
     public interface IAppConfigurator
     {
-        void ProjectToTest(WebApplication webApplication);
-        void WithWebServer(IWebServer webServer);
-        void WithWebDriver(Func<IWebDriver> webDriver);
-        void UsingCamera(ICamera camera);
-        void UsingLogger(ILogFactory logFactory);
+        AppConfigurator ProjectToTest(WebApplication webApplication);
+        AppConfigurator WithWebServer(IWebServer webServer);
+        AppConfigurator WithWebDriver(Func<IWebDriver> webDriver);
+        AppConfigurator UsingCamera(ICamera camera);
+        AppConfigurator UsingLogger(ILogFactory logFactory);
     }
 }


### PR DESCRIPTION
Created a TestObjectFactory to return a "TestableAppConfigurator." As the name infers, this feels like a step towards a TestableAppConfigurator class using the testable pattern.

http://www.mattwrock.com/post/2011/12/07/Unit-Testing-ASPNet-Http-Handlers-and-a-discussion-of-Auto-Mocking-and-the-Testable-pattern.aspx

Another route might be to make the AppConfigurator class itself (or configuration generally) more testable and I would be interested if anybody has any thoughts on how that might be improved.

I made the AppConfigurator support more of a traditional builder pattern as well as the action based configuration it already has. I don't know if this increases flexibility or confusion?
