### PR TITLE
AppConfigurator validate sequence causing failures

### DIFF
--- a/src/TestStack.Seleno/Configuration/AppConfigurator.cs
+++ b/src/TestStack.Seleno/Configuration/AppConfigurator.cs
@@ -18,18 +18,11 @@ namespace TestStack.Seleno.Configuration
         private Func<IWebDriver> _webDriver = BrowserFactory.FireFox;
         private ILogFactory _logFactory = new ConsoleLogFactory();
 
-        private void Validate()
-        {
-            if (_webServer.GetType() == typeof(IisExpressWebServer) && _webApplication == null)
-                throw new AppConfigurationException("The web application must be set.");
-        }
-
         public ISelenoApplication CreateApplication()
         {
-            Validate();
             _logFactory
                 .GetLogger(GetType())
-                .InfoFormat("Seleno v{0}, .NET Framework v{1}", 
+                .InfoFormat("Seleno v{0}, .NET Framework v{1}",
                     typeof(SelenoApplicationRunner).Assembly.GetName().Version, Environment.Version);
 
             var container = BuildContainer();
@@ -55,7 +48,7 @@ namespace TestStack.Seleno.Configuration
         public void WithWebServer(IWebServer webServer)
         {
             _webServer = webServer;
-        } 
+        }
 
         public void WithWebDriver(Func<IWebDriver> webDriver)
         {

--- a/src/TestStack.Seleno/Configuration/SelenoApplicationRunner.cs
+++ b/src/TestStack.Seleno/Configuration/SelenoApplicationRunner.cs
@@ -8,23 +8,12 @@ namespace TestStack.Seleno.Configuration
 {
     public static class SelenoApplicationRunner
     {
-        static readonly ILog _log = LogManager.GetLogger("Seleno");
+        private static readonly ILog Log = LogManager.GetLogger("Seleno");
         public static ISelenoApplication Host { get; private set; }
-
-        private static ISelenoApplication New(Action<IAppConfigurator> configure)
-        {
-            if (configure == null)
-                throw new ArgumentNullException("configure");
-
-            var configurator = new AppConfigurator();
-            configure(configurator);
-            Host = configurator.CreateApplication();
-            Host.Initialize();
-
-            return Host;
-        }
-
-        public static void Run(string webProjectFolder, int portNumber, Action<IAppConfigurator> configure = null)
+       
+        public static void Run(string webProjectFolder, 
+                               int portNumber, 
+                               Action<IAppConfigurator> configure = null)
         {
             var webApplication = new WebApplication(ProjectLocation.FromFolder(webProjectFolder), portNumber);
             Run(webApplication, configure);
@@ -46,7 +35,8 @@ namespace TestStack.Seleno.Configuration
             }
             catch (Exception ex)
             {
-                _log.Error("The Seleno Application exited abnormally with an exception", ex);
+                Log.Error("The Seleno Application exited abnormally with an exception", ex);
+                throw;
             }
         }
 
@@ -64,9 +54,22 @@ namespace TestStack.Seleno.Configuration
             }
             catch (Exception ex)
             {
-                _log.Error("The Seleno Application exited abnormally with an exception", ex);
+                Log.Error("The Seleno Application exited abnormally with an exception", ex);
+                throw;
             }
         }
 
+        private static ISelenoApplication New(Action<IAppConfigurator> configure)
+        {
+            if (configure == null)
+                throw new ArgumentNullException("configure");
+
+            var configurator = new AppConfigurator();
+            configure(configurator);
+            Host = configurator.CreateApplication();
+            Host.Initialize();
+
+            return Host;
+        }
     }
 }

--- a/src/TestStack.Seleno/Configuration/WebServers/IisExpressWebServer.cs
+++ b/src/TestStack.Seleno/Configuration/WebServers/IisExpressWebServer.cs
@@ -13,6 +13,8 @@ namespace TestStack.Seleno.Configuration.WebServers
 
         public IisExpressWebServer(WebApplication application)
         {
+            if (application == null)
+                throw new AppConfigurationException("The web application must be set.");
             _application = application;
         }
 

--- a/src/TestStack.Seleno/PageObjects/Actions/ElementFinder.cs
+++ b/src/TestStack.Seleno/PageObjects/Actions/ElementFinder.cs
@@ -13,6 +13,8 @@ namespace TestStack.Seleno.PageObjects.Actions
 
         internal ElementFinder(RemoteWebDriver browser)
         {
+            if(browser == null)
+                throw new ArgumentNullException("browser");
             Browser = browser;
         }
 
@@ -49,7 +51,5 @@ namespace TestStack.Seleno.PageObjects.Actions
 
             return result;
         }
-
-
     }
 }

--- a/src/TestStack.Seleno/PageObjects/Actions/PageNavigator.cs
+++ b/src/TestStack.Seleno/PageObjects/Actions/PageNavigator.cs
@@ -16,6 +16,8 @@ namespace TestStack.Seleno.PageObjects.Actions
 
         internal PageNavigator(RemoteWebDriver browser, IScriptExecutor executor)
         {
+            if (browser == null) throw new ArgumentNullException("browser");
+            if (executor == null) throw new ArgumentNullException("executor");
             Browser = browser;
             _executor = executor;
         }

--- a/src/TestStack.Seleno/PageObjects/Actions/ScriptExecutor.cs
+++ b/src/TestStack.Seleno/PageObjects/Actions/ScriptExecutor.cs
@@ -14,6 +14,9 @@ namespace TestStack.Seleno.PageObjects.Actions
 
         internal ScriptExecutor(RemoteWebDriver browser, IElementFinder finder, ICamera camera)
         {
+            if (browser == null) throw new ArgumentNullException("browser");
+            if (finder == null) throw new ArgumentNullException("finder");
+            if (camera == null) throw new ArgumentNullException("camera");
             Browser = browser;
             _finder = finder;
             _camera = camera;
@@ -67,8 +70,8 @@ namespace TestStack.Seleno.PageObjects.Actions
         {
             javaScriptExecutor = javaScriptExecutor ?? Browser;
 
-            object untypedValue = javaScriptExecutor.ExecuteScript("return " + javascriptToBeExecuted);
-            object result = untypedValue.TryConvertTo(returnType, null);
+            var untypedValue = javaScriptExecutor.ExecuteScript("return " + javascriptToBeExecuted);
+            var result = untypedValue.TryConvertTo(returnType, null);
 
             return result;
         }

--- a/src/TestStack.Seleno/PageObjects/UiComponent.cs
+++ b/src/TestStack.Seleno/PageObjects/UiComponent.cs
@@ -17,6 +17,8 @@ namespace TestStack.Seleno.PageObjects
 
         public UiComponent()
         {
+            if (SelenoApplicationRunner.Host == null)
+                throw new AppConfigurationException("SelenoApplicationRunner.Host is not set");
             Browser = SelenoApplicationRunner.Host.Browser as RemoteWebDriver;
             _camera = SelenoApplicationRunner.Host.Camera;
             ElementFinder = new ElementFinder(Browser);


### PR DESCRIPTION
Commit Notes : rearranged the Appconfigurator so validation can pass. Validation has been moved to the type in question so the AppConfigurator does not need to know about the internals of IisExpressWebServer (demeters law). Some ctor dbc checks to prevent null ref exception and their lack of stack trace.
