### PR TITLE
Adding ability to dump DOM out like a screenshot

### DIFF
--- a/src/TestStack.Seleno/Configuration/AppConfigurator.cs
+++ b/src/TestStack.Seleno/Configuration/AppConfigurator.cs
@@ -8,6 +8,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
 using TestStack.Seleno.Configuration.Contracts;
 using TestStack.Seleno.Configuration.ControlIdGenerators;
+using TestStack.Seleno.Configuration.DomCaptures;
 using TestStack.Seleno.Configuration.Registration;
 using TestStack.Seleno.Configuration.Screenshots;
 using TestStack.Seleno.Configuration.WebServers;
@@ -32,6 +33,7 @@ namespace TestStack.Seleno.Configuration
             ContainerBuilder.Register(c => new IisExpressWebServer(WebApplication))
                 .As<IWebServer>().SingleInstance();
             UsingControlIdGenerator(new DefaultControlIdGenerator());
+            UsingDomCapture(new NullDomCapture());
         }
 
         public ISelenoApplication CreateApplication()
@@ -159,6 +161,21 @@ namespace TestStack.Seleno.Configuration
         {
             ContainerBuilder.Register(c => controlIdGenerator)
                 .As<IControlIdGenerator>().SingleInstance();
+            return this;
+        }
+
+        public IAppConfigurator UsingDomCapture(string capturePath)
+        {
+            return UsingDomCapture(new FileDomCapture(capturePath));
+        }
+
+        public IAppConfigurator UsingDomCapture(IDomCapture domCapture)
+        {
+            ContainerBuilder.Register(c => domCapture)
+                .As<IDomCapture>().SingleInstance()
+                .OnActivated(x => {
+                    x.Instance.Browser = x.Context.Resolve<IWebDriver>();
+                });
             return this;
         }
     }

--- a/src/TestStack.Seleno/Configuration/Contracts/IAppConfigurator.cs
+++ b/src/TestStack.Seleno/Configuration/Contracts/IAppConfigurator.cs
@@ -87,6 +87,9 @@ namespace TestStack.Seleno.Configuration.Contracts
         /// <param name="name">The name of the environment variable</param>
         /// <param name="value">The optional value of the environment variable</param>
         IAppConfigurator WithEnvironmentVariable(string name, string value = null);
+
+        IAppConfigurator UsingDomCapture(string capturePath);
+        IAppConfigurator UsingDomCapture(IDomCapture domCapture);
     }
 
     internal interface IInternalAppConfigurator : IAppConfigurator

--- a/src/TestStack.Seleno/Configuration/Contracts/IDomCapture.cs
+++ b/src/TestStack.Seleno/Configuration/Contracts/IDomCapture.cs
@@ -1,0 +1,18 @@
+﻿using OpenQA.Selenium;
+
+namespace TestStack.Seleno.Configuration.Contracts
+{
+    public interface IDomCapture
+    {
+        /// <summary>
+        /// The browser that is viewing the page the DOM was captured from.
+        /// </summary>
+        IWebDriver Browser { get; set; }
+
+        /// <summary>
+        /// Captures the DOM using the given filename (if specified).
+        /// </summary>
+        /// <param name="fileName">The filename to use to save the DOM as</param>
+        void CaptureDom(string fileName = null);
+    }
+}

--- a/src/TestStack.Seleno/Configuration/DomCaptures/FileDomCapture.cs
+++ b/src/TestStack.Seleno/Configuration/DomCaptures/FileDomCapture.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using OpenQA.Selenium;
+using TestStack.Seleno.Configuration.Contracts;
+
+namespace TestStack.Seleno.Configuration.DomCaptures
+{
+    /// <summary>
+    /// Captures the DOM to a file
+    /// </summary>
+    public class FileDomCapture : IDomCapture
+    {
+        private readonly string _capturePath;
+        public FileDomCapture(string capturePath)
+        {
+            _capturePath = capturePath;
+        }
+
+        public IWebDriver Browser { get; set; }
+
+        public void CaptureDom(string fileName = null)
+        {
+            if (!Directory.Exists(_capturePath))
+                Directory.CreateDirectory(_capturePath);
+
+            var windowTitle = this.Browser.Title;
+            fileName = (fileName ?? string.Format("{0}{1}.html", windowTitle, DateTime.Now.ToFileTime()).Replace(':', '.'));
+
+            var outputPath = Path.Combine(_capturePath, fileName);
+            var pathChars = Path.GetInvalidPathChars();
+            var stringBuilder = new StringBuilder(outputPath);
+            var array = pathChars;
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                var item = array[i];
+                stringBuilder.Replace(item, '.');
+            }
+            var screenShotPath = stringBuilder.ToString();
+
+            using (var writer = new StreamWriter(screenShotPath))
+                writer.Write(Browser.PageSource);
+        }
+    }
+}

--- a/src/TestStack.Seleno/Configuration/DomCaptures/NullDomCapture.cs
+++ b/src/TestStack.Seleno/Configuration/DomCaptures/NullDomCapture.cs
@@ -1,0 +1,18 @@
+﻿using OpenQA.Selenium;
+using TestStack.Seleno.Configuration.Contracts;
+
+namespace TestStack.Seleno.Configuration.DomCaptures
+{
+    /// <summary>
+    /// DOM Capturer that doesn't actually do anything
+    /// </summary>
+    public class NullDomCapture : IDomCapture
+    {
+        public IWebDriver Browser { get; set; }
+
+        public void CaptureDom(string fileName = null)
+        {
+            //do nothing
+        }
+    }
+}

--- a/src/TestStack.Seleno/Configuration/Interceptors/DomCaptureProxyInterceptor.cs
+++ b/src/TestStack.Seleno/Configuration/Interceptors/DomCaptureProxyInterceptor.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Castle.Core.Logging;
+using Castle.DynamicProxy;
+using TestStack.Seleno.Configuration.Contracts;
+
+namespace TestStack.Seleno.Configuration.Interceptors
+{
+    class DomCaptureProxyInterceptor : IInterceptor
+    {
+        private readonly IDomCapture _domCapture;
+        private readonly string _filename;
+        private readonly ILogger _logger;
+
+        public DomCaptureProxyInterceptor(IDomCapture domCapture, string filename, ILogger logger)
+        {
+            _domCapture = domCapture;
+            _filename = filename;
+            _logger = logger;
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            try
+            {
+                invocation.Proceed();
+            }
+            catch (SelenoReceivedException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                _logger.ErrorFormat(e, "Error invoking {0}.{1}", invocation.TargetType.Name, invocation.Method.Name);
+                var filename = _filename + "_" + DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss") + ".html";
+
+                try
+                {
+                    _domCapture.CaptureDom(filename);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error("Error saving a DOM", ex);
+                }
+
+                throw new SelenoReceivedException(e);
+            }
+        }
+    }
+}

--- a/src/TestStack.Seleno/Configuration/Registration/RegistrationExtensions.cs
+++ b/src/TestStack.Seleno/Configuration/Registration/RegistrationExtensions.cs
@@ -43,6 +43,8 @@ namespace TestStack.Seleno.Configuration.Registration
                 .SingleInstance();
             builder.Register(CreateCameraProxyFor<TConcrete, TInterface>)
                 .SingleInstance();
+            builder.Register(CreateDomCaptureProxyFor<TConcrete, TInterface>)
+                .SingleInstance();
         }
 
         private static TInterface CreateCameraProxyFor<TConcrete, TInterface>(IComponentContext c)
@@ -50,6 +52,13 @@ namespace TestStack.Seleno.Configuration.Registration
             where TInterface : class
         {
             return c.Resolve<ProxyGenerator>().CreateInterfaceProxyWithTarget<TInterface>(c.Resolve<TConcrete>(), new CameraProxyInterceptor(c.Resolve<ICamera>(), typeof(TConcrete).Name, c.Resolve<ILoggerFactory>().Create(typeof(TConcrete))));
+        }
+
+        private static TInterface CreateDomCaptureProxyFor<TConcrete, TInterface>(IComponentContext c)
+            where TConcrete : TInterface
+            where TInterface : class
+        {
+            return c.Resolve<ProxyGenerator>().CreateInterfaceProxyWithTarget<TInterface>(c.Resolve<TConcrete>(), new DomCaptureProxyInterceptor(c.Resolve<IDomCapture>(), typeof(TConcrete).Name, c.Resolve<ILoggerFactory>().Create(typeof(TConcrete))));
         }
     }
 }

--- a/src/TestStack.Seleno/TestStack.Seleno.csproj
+++ b/src/TestStack.Seleno/TestStack.Seleno.csproj
@@ -80,11 +80,15 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\Contracts\IDomCapture.cs" />
     <Compile Include="Configuration\ControlIdGenerators\Html401IdUtil.cs" />
+    <Compile Include="Configuration\DomCaptures\FileDomCapture.cs" />
+    <Compile Include="Configuration\DomCaptures\NullDomCapture.cs" />
     <Compile Include="Configuration\Interceptors\CameraProxyInterceptor.cs" />
     <Compile Include="Configuration\Contracts\IControlIdGenerator.cs" />
     <Compile Include="Configuration\ControlIdGenerators\DefaultControlIdGenerator.cs" />
     <Compile Include="Configuration\ControlIdGenerators\MvcControlIdGenerator.cs" />
+    <Compile Include="Configuration\Interceptors\DomCaptureProxyInterceptor.cs" />
     <Compile Include="Configuration\Registration\UiComponentRegistrationSource.cs" />
     <Compile Include="Configuration\Registration\RegistrationExtensions.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />


### PR DESCRIPTION
I've hit a few instances where the screenshot API isn't enough to give me a look at what is in the DOM, maybe the DOM structure has changed and I want to see what my selector should really be hitting (especially useful if you're using AngularJS).

The new `IDomCapture` allows you to do just that, dump the DOM out as a string when an error occurs, just like a screenshot.

I've included the default implementation (write to the FS) and a Null implementation. I've also added a proxy class like the Camera uses. I'm not really familiar with Castle proxies so I'm not sure if you can chain them (ie - have both the Camera and DomCapture running), but as I said this is the first pass and looking for feedback.

I'm using a modified version of this in my own app (wrote my own camera that wrapped `FileCamera` to dump out the DOM before doing the screenshot).
