### PR TITLE
Fix broken documentation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ If you are upgrading from an earlier version then note that there are a [number 
         }
 
 ## Tutorials / advanced usage
-Check out [our documentation](http://docs.teststack.net/seleno/).
+Check out [our documentation](http://seleno.teststack.net/docs/introduction-to-seleno).
 
 ## Background information on Page Objects
 

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ If you are upgrading from an earlier version then note that there are a [number 
         }
 
 ## Tutorials / advanced usage
-Check out [our documentation](http://seleno.teststack.net/docs/introduction-to-seleno).
+Check out [our documentation](http://seleno.teststack.net/).
 
 ## Background information on Page Objects
 


### PR DESCRIPTION
**Readme.md**
The link to Seleno documentation is broken. 

I've updated the URL to point to: http://seleno.teststack.net/docs/introduction-to-seleno