### PR TITLE
Update TableReader.cs

### DIFF
--- a/src/TestStack.Seleno/PageObjects/Actions/TableReader.cs
+++ b/src/TestStack.Seleno/PageObjects/Actions/TableReader.cs
@@ -136,7 +136,8 @@ namespace TestStack.Seleno.PageObjects.Actions
                     .FindElements(Locators.By.jQuery(selector))
                     .Select(e => e.GetAttribute(PropertyNameAttribute)
                                   .Split('_')
-                                  .Last());
+                                  .Last())
+                    .ToList();
         }
 
 


### PR DESCRIPTION
Materialize the result returned from GetColumnNames, otherwise enumerating the result causes elements of code to be reexucuted repeatedly which makes things very slow. Appears to fix #225