### PR TITLE
Fixed DropDown.SelectElementByText triggering change event.

### DIFF
--- a/src/TestStack.Seleno/PageObjects/Controls/DropDown.cs
+++ b/src/TestStack.Seleno/PageObjects/Controls/DropDown.cs
@@ -21,7 +21,7 @@ namespace TestStack.Seleno.PageObjects.Controls
 
         public virtual void SelectElementByText(string optionText)
         {
-            var scriptToExecute = string.Format("$('#{0} option:contains(\"{1}\")').attr('selected',true)", Id, optionText.ToJavaScriptString());
+            var scriptToExecute = string.Format("$('#{0} option:contains(\"{1}\")').attr('selected',true).change()", Id, optionText.ToJavaScriptString());
             Execute.Script(scriptToExecute);
         }
 


### PR DESCRIPTION
I've added in the code mentioned in Issue #220 by @brunoshine to allow it to trigger the change event correctly.