### PR TITLE
Fixed GetSolutionFolderPath null reference exception when no solution file is found.

### DIFF
--- a/src/TestStack.Seleno/Configuration/WebServers/ProjectLocation.cs
+++ b/src/TestStack.Seleno/Configuration/WebServers/ProjectLocation.cs
@@ -11,7 +11,7 @@ namespace TestStack.Seleno.Configuration.WebServers
 
     public class ProjectLocation : IProjectLocation
     {
-        public string FullPath { get; private set; }
+        public string FullPath { get; }
 
         private ProjectLocation(string fullPath)
         {
@@ -30,28 +30,37 @@ namespace TestStack.Seleno.Configuration.WebServers
 
         public static ProjectLocation FromFolder(string webProjectFolderName)
         {
-            string solutionFolder = GetSolutionFolderPath();
-            string projectPath = FindSubFolderPath(solutionFolder, webProjectFolderName);
+            var solutionFolder = GetSolutionFolderPath();
+            var projectPath = FindSubFolderPath(solutionFolder, webProjectFolderName);
             return new ProjectLocation(projectPath);
         }
 
-        private static string GetSolutionFolderPath()
+        private static string GetSolutionFolderPath(string basePath = null)
         {
-            var directory = new DirectoryInfo(Environment.CurrentDirectory);
+            var baseDir = basePath ?? AppDomain.CurrentDomain.RelativeSearchPath;
 
-            while (directory.GetFiles("*.sln").Length == 0)
+            var directory = new DirectoryInfo(baseDir);
+
+            while (directory?.GetFiles("*.sln").Length == 0)
             {
                 directory = directory.Parent;
             }
-            return directory.FullName;
+
+            return directory?.FullName ??
+                   GetSolutionFolderPath(AppDomain.CurrentDomain.BaseDirectory);
         }
 
         private static string FindSubFolderPath(string rootFolderPath, string folderName)
         {
+            if (string.IsNullOrEmpty(rootFolderPath))
+            {
+                throw new DirectoryNotFoundException();
+            }
+
             var directory = new DirectoryInfo(rootFolderPath);
 
             directory = (directory.GetDirectories("*", SearchOption.AllDirectories)
-                .Where(folder => folder.Name.ToLower() == folderName.ToLower()))
+                .Where(folder => string.Equals(folder.Name, folderName, StringComparison.CurrentCultureIgnoreCase)))
                 .FirstOrDefault();
 
             if (directory == null)

--- a/src/TestStack.Seleno/Configuration/WebServers/ProjectLocation.cs
+++ b/src/TestStack.Seleno/Configuration/WebServers/ProjectLocation.cs
@@ -11,7 +11,7 @@ namespace TestStack.Seleno.Configuration.WebServers
 
     public class ProjectLocation : IProjectLocation
     {
-        public string FullPath { get; }
+        public string FullPath { get; private set; }
 
         private ProjectLocation(string fullPath)
         {
@@ -41,13 +41,12 @@ namespace TestStack.Seleno.Configuration.WebServers
 
             var directory = new DirectoryInfo(baseDir);
 
-            while (directory?.GetFiles("*.sln").Length == 0)
+            while (directory != null && directory.GetFiles("*.sln").Length == 0)
             {
                 directory = directory.Parent;
             }
 
-            return directory?.FullName ??
-                   GetSolutionFolderPath(AppDomain.CurrentDomain.BaseDirectory);
+            return directory == null ? GetSolutionFolderPath(AppDomain.CurrentDomain.BaseDirectory) : directory.FullName;
         }
 
         private static string FindSubFolderPath(string rootFolderPath, string folderName)


### PR DESCRIPTION
Fixed GetSolutionFolderPath. It will now search the current folder, as well as the applications base directory. This helps, when using ReSharper's test runner inside Visual Studio.
FromFolder will now also throw a DirectoryNotFoundException, when no solution file can be found.
