### PR TITLE
Reverted ProjectLocation to use Environment.CurrentDirectory

### DIFF
--- a/src/TestStack.Seleno/Configuration/WebServers/ProjectLocation.cs
+++ b/src/TestStack.Seleno/Configuration/WebServers/ProjectLocation.cs
@@ -37,7 +37,7 @@ namespace TestStack.Seleno.Configuration.WebServers
 
         private static string GetSolutionFolderPath(string basePath = null)
         {
-            var baseDir = basePath ?? AppDomain.CurrentDomain.RelativeSearchPath;
+            var baseDir = basePath ?? Environment.CurrentDirectory;
 
             var directory = new DirectoryInfo(baseDir);
 


### PR DESCRIPTION
AppDomain.CurrentDomain.RelativeSearchPath broke 50 acceptance tests because it returned empty string (locally with ReSharper runner and on build server). Reverted to Environment.CurrentDirectory to get all the tests passing again. 