### PR TITLE
Initialise browser lazily so that web server can start before web dri…

### DIFF
--- a/src/TestStack.Seleno/Configuration/SelenoApplication.cs
+++ b/src/TestStack.Seleno/Configuration/SelenoApplication.cs
@@ -19,8 +19,13 @@ namespace TestStack.Seleno.Configuration
         private bool _disposed;
 
         private readonly IContainer _container;
+        private IWebDriver _browser;
 
-        public IWebDriver Browser { get; }
+        public IWebDriver Browser
+        {
+            get { return _browser ?? (_browser = _container.Resolve<IWebDriver>()); }
+        }
+
         public ICamera Camera { get; }
         public IDomCapture DomCapture { get; }
         public ILogger Logger { get; }
@@ -33,7 +38,6 @@ namespace TestStack.Seleno.Configuration
         public SelenoApplication(IContainer container)
         {
             _container = container;
-            Browser = _container.Resolve<IWebDriver>();
             Camera = _container.Resolve<ICamera>();
             DomCapture = _container.Resolve<IDomCapture>();
             Logger = _container.Resolve<ILoggerFactory>().Create(GetType());

--- a/src/TestStack.Seleno/Configuration/SelenoHost.cs
+++ b/src/TestStack.Seleno/Configuration/SelenoHost.cs
@@ -74,13 +74,7 @@ namespace TestStack.Seleno.Configuration
         /// <param name="configure">Any configuration changes you would like to make</param>
         public void Run(Action<IAppConfigurator> configure)
         {
-            Action<IAppConfigurator> action = x =>
-            {
-                if (configure != null)
-                    configure(x);
-            };
-
-            Application = CreateApplication(action);
+            Application = CreateApplication(x => configure?.Invoke(x));
             AppDomain.CurrentDomain.DomainUnload += CurrentDomainDomainUnload;
         }
 


### PR DESCRIPTION
…ver gets instantied:

 => For example browser stack requires to start a local tunnelled connection before instantiating the remote driver which needs browser.locale capabilities to be set to true:

 https://github.com/browserstack/browserstack-local-csharp/blob/master/BrowserStackLocalExample/BrowserStackExample/Example.cs
